### PR TITLE
Transition Cities to Separate Property in Database

### DIFF
--- a/scripts/CityList.js
+++ b/scripts/CityList.js
@@ -12,11 +12,16 @@ document.addEventListener(
             const cityId = parseInt(clickTarget.dataset.id)
             
             const walkers = getWalkers()
+            const localWalkers = []
             for (const walker of walkers) {
                 if (walker.cityId === cityId) {
-                    window.alert(`${walker.name} is servicing this city`)
+                    localWalkers.push(walker.name)
                 }
             }
+            
+            const localWalkersString = localWalkers.join(" and ")
+            
+            window.alert(`${localWalkersString} is servicing this city`)
         }
     }
 )

--- a/scripts/CityList.js
+++ b/scripts/CityList.js
@@ -1,4 +1,4 @@
-import { getCities } from "./database.js"
+import { getCities, getWalkers } from "./database.js"
 
 const cities = getCities()
 
@@ -9,13 +9,19 @@ document.addEventListener(
         const clickTarget = clickEvent.target
 
         if (clickTarget.dataset.type === "city") {
-            window.alert(`${clickTarget.dataset.walkername} is servicing this city`)
+            const cityId = parseInt(clickTarget.dataset.id)
+            
+            const walkers = getWalkers()
+            for (const walker of walkers) {
+                if (walker.cityId === cityId) {
+                    window.alert(`${walker.name} is servicing this city`)
+                }
+            }
         }
     }
 )
 
 export const CityList = () => {
-    
     
     let citiesHTML = "<ul>"
 

--- a/scripts/CityList.js
+++ b/scripts/CityList.js
@@ -15,6 +15,8 @@ document.addEventListener(
 )
 
 export const CityList = () => {
+    
+    
     let citiesHTML = "<ul>"
 
     for (const walker of walkers) {

--- a/scripts/CityList.js
+++ b/scripts/CityList.js
@@ -1,6 +1,6 @@
-import { getWalkers } from "./database.js"
+import { getCities } from "./database.js"
 
-const walkers = getWalkers()
+const cities = getCities()
 
 
 document.addEventListener(
@@ -19,10 +19,10 @@ export const CityList = () => {
     
     let citiesHTML = "<ul>"
 
-    for (const walker of walkers) {
-        citiesHTML += `<li data-walkerName="${walker.name}"
+    for (const city of cities) {
+        citiesHTML += `<li data-id="${city.id}"
                             data-type="city"
-                            >${walker.city}
+                            >${city.name}
                         </li>`
     }
 

--- a/scripts/Walkers.js
+++ b/scripts/Walkers.js
@@ -1,5 +1,4 @@
-import { getWalkers } from "./database.js"
-
+import { getWalkers, getCities } from "./database.js"
 
 document.addEventListener(
     "click",
@@ -7,11 +6,19 @@ document.addEventListener(
         const elementClickedOn = clickEvent.target
         
         if (elementClickedOn.dataset.type === "walker") {
-            window.alert(`This walker works in ${elementClickedOn.dataset.city}`)
+            const cityId = parseInt(elementClickedOn.dataset.cityid)
+            const cities = getCities()
+
+            for (const city of cities) {
+                if (city.id === cityId) {
+                    window.alert(`This walker works in ${city.name}`)
+                    break
+                }
+            }
         }
     })
     
-    export const Walkers = () => {
+export const Walkers = () => {
     const walkers = getWalkers()
     
     let walkerHTML = "<ul>"

--- a/scripts/Walkers.js
+++ b/scripts/Walkers.js
@@ -18,7 +18,7 @@ export const Walkers = () => {
 
     for (const walker of walkers) {
         walkerHTML += `<li data-id="${walker.id}" 
-                            data-city="${walker.city}"
+                            data-cityId="${walker.cityId}"
                             data-type="walker">
                             ${walker.name}
                         </li>`

--- a/scripts/Walkers.js
+++ b/scripts/Walkers.js
@@ -1,19 +1,19 @@
 import { getWalkers } from "./database.js"
 
-const walkers = getWalkers()
-
 
 document.addEventListener(
     "click",
     (clickEvent) => {
         const elementClickedOn = clickEvent.target
-
+        
         if (elementClickedOn.dataset.type === "walker") {
             window.alert(`This walker works in ${elementClickedOn.dataset.city}`)
         }
     })
-
-export const Walkers = () => {
+    
+    export const Walkers = () => {
+    const walkers = getWalkers()
+    
     let walkerHTML = "<ul>"
 
     for (const walker of walkers) {

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -150,3 +150,6 @@ export const getPets = () => {
     return database.pets.map(pet => ({...pet}))
 }
 
+export const getCities = () => {
+    return database.cities.map(city => ({...city}))
+}

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -10,52 +10,52 @@ const database = {
         id: 1,
         name: "Alphonse Meron",
         email: "ameron0@mashable.com",
-        city: "Chicago"
+        city: 1
     }, {
         id: 2,
         name: "Damara Pentecust",
         email: "dpentecust1@apache.org",
-        city: "White Plains"
+        city: 2
     }, {
         id: 3,
         name: "Anna Bowton",
         email: "abowton2@wisc.edu",
-        city: "Sarasota"
+        city: 3
     }, {
         id: 4,
         name: "Hunfredo Drynan",
         email: "hdrynan3@bizjournals.com",
-        city: "San Diego"
+        city: 4
     }, {
         id: 5,
         name: "Elmira Bick",
         email: "ebick4@biblegateway.com",
-        city: "Boise"
+        city: 5
     }, {
         id: 6,
         name: "Bernie Dreger",
         email: "bdreger5@zimbio.com",
-        city: "Denver"
+        city: 6
     }, {
         id: 7,
         name: "Rolando Gault",
         email: "rgault6@google.com",
-        city: "Tucson"
+        city: 7
     }, {
         id: 8,
         name: "Tiffanie Tubby",
         email: "ttubby7@intel.com",
-        city: "Phoenix"
+        city: 8
     }, {
         id: 9,
         name: "Tomlin Cutill",
         email: "tcutill8@marketwatch.com",
-        city: "Minneapolis"
+        city: 9
     }, {
         id: 10,
         name: "Arv Biddle",
         email: "abiddle9@cafepress.com",
-        city: "Pittsburgh"
+        city: 10
     }],
     pets: [{
         id: 1,

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -10,52 +10,52 @@ const database = {
         id: 1,
         name: "Alphonse Meron",
         email: "ameron0@mashable.com",
-        city: 1
+        cityId: 1
     }, {
         id: 2,
         name: "Damara Pentecust",
         email: "dpentecust1@apache.org",
-        city: 2
+        cityId: 2
     }, {
         id: 3,
         name: "Anna Bowton",
         email: "abowton2@wisc.edu",
-        city: 3
+        cityId: 3
     }, {
         id: 4,
         name: "Hunfredo Drynan",
         email: "hdrynan3@bizjournals.com",
-        city: 4
+        cityId: 4
     }, {
         id: 5,
         name: "Elmira Bick",
         email: "ebick4@biblegateway.com",
-        city: 5
+        cityId: 5
     }, {
         id: 6,
         name: "Bernie Dreger",
         email: "bdreger5@zimbio.com",
-        city: 6
+        cityId: 6
     }, {
         id: 7,
         name: "Rolando Gault",
         email: "rgault6@google.com",
-        city: 7
+        cityId: 7
     }, {
         id: 8,
         name: "Tiffanie Tubby",
         email: "ttubby7@intel.com",
-        city: 8
+        cityId: 8
     }, {
         id: 9,
         name: "Tomlin Cutill",
         email: "tcutill8@marketwatch.com",
-        city: 9
+        cityId: 9
     }, {
         id: 10,
         name: "Arv Biddle",
         email: "abiddle9@cafepress.com",
-        city: 10
+        cityId: 10
     }],
     pets: [{
         id: 1,

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -97,7 +97,49 @@ const database = {
         id: 10,
         name: "Panda",
         walkerId: 7
-    }]
+    }],
+    cities: [
+        {
+            id: 1,
+            name: "Chicago"
+        },
+        {
+            id: 2,
+            name: "White Plains"
+        },
+        {
+            id: 3,
+            name: "Sarasota"
+        },
+        {
+            id: 4,
+            name: "San Diego"
+        },
+        {
+            id: 5,
+            name: "Boise"
+        },
+        {
+            id: 6,
+            name: "Denver"
+        },
+        {
+            id: 7,
+            name: "Tucson"
+        },
+        {
+            id: 8,
+            name: "Phoenix"
+        },
+        {
+            id: 9,
+            name: "Minneapolis"
+        },
+        {
+            id: 10,
+            name: "Pittsburgh"
+        }
+    ]
 }
 
 export const getWalkers = () => {

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -56,6 +56,11 @@ const database = {
         name: "Arv Biddle",
         email: "abiddle9@cafepress.com",
         cityId: 10
+    }, {
+        id: 11,
+        name: "Amelia Anderson",
+        email: "amelia@andersonfam.com",
+        cityId: 4
     }],
     pets: [{
         id: 1,


### PR DESCRIPTION
### Purpose
Moved cities to being a property in the database, so that multiple Walkers could use the same city. As such, the city String property in walkers was transitioned to using a foreign key, and was renamed to cityId. Relevant HTML generators and click events were modified to use the new system.

### Files Changed
- cities property was added, and walkers.city String property was changed to walkers.cityId fk, in `database.js`
- HTML generator and click events were swapped to use new fk system for cities in `walkers.js`
- HTML generator and click events were swapped to use new fk system for cities in `cityList.js` 